### PR TITLE
Make fib(1) more consistent with other commands.

### DIFF
--- a/fibscript.py
+++ b/fibscript.py
@@ -6,7 +6,7 @@ def fibonacci(n):
         print("ERROR: Parameter must be one positive integer.")
         return
     elif n == 1:
-        print(sequence[0])
+        print(f"[{sequence[0]}]")
         return
     elif n == 2:
         print(sequence)


### PR DESCRIPTION
Currently fib(1) prints just "0\n", while other commands like fib(3) print the result in a list format ("[0, 1, 1]\n"). In this pull request I attempted fixing this consistency problem by adding "[]" around result of fib(1).